### PR TITLE
make CatalogSlide available in item attribute

### DIFF
--- a/src/classes/Unicity/MappingService/Impl/Hydra/API/Master/Model/LineItem.json
+++ b/src/classes/Unicity/MappingService/Impl/Hydra/API/Master/Model/LineItem.json
@@ -72,12 +72,7 @@
 					"properties": {
 						"content": {
 							"patternProperties": {
-								"/^description@([a-z]{2})$/": {
-									"type": "string"
-								}
-							},
-							"properties": {
-								"description": {
+								"/^description(@[a-z]{2})?$/": {
 									"type": "string"
 								}
 							},

--- a/src/classes/Unicity/MappingService/Impl/Hydra/API/Master/Model/LineItem.json
+++ b/src/classes/Unicity/MappingService/Impl/Hydra/API/Master/Model/LineItem.json
@@ -68,6 +68,24 @@
 					},
 					"type": "object"
 				},
+				"catalogSlide": {
+					"properties": {
+						"content": {
+							"patternProperties": {
+								"/^description@([a-z]{2})$/": {
+									"type": "string"
+								}
+							},
+							"properties": {
+								"description": {
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
+				},
 				"dateCreated": {
 					"pattern-disabled": "/^[0-9]{4}(-[0-9]{2}(-[0-9]{2}(T[0-9]{2}:[0-9]{2}(:[0-9]{2}(\\.[0-9]+)?)?)?[+-][0-9]{2}:[0-9]{2})?)?$/",
 					"type": "string"


### PR DESCRIPTION
Although the CatalogSlide is available as a root attribute of the the item, the item->item->catalogSlide is referred to in the code as well. 